### PR TITLE
Replace `typing.Union` with `|`.

### DIFF
--- a/src/pytest_freethreaded/plugin.py
+++ b/src/pytest_freethreaded/plugin.py
@@ -3,7 +3,6 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 import threading
 from itertools import chain, repeat
-from typing import Union
 
 import logging
 
@@ -58,7 +57,7 @@ class ConcurrencyError(Exception):
 
 def get_one_result(
     item: pytest.Item, barrier: threading.Barrier
-) -> Union[None, Exception]:
+) -> None | Exception:
     try:
         barrier.wait()
         return item.runtest()


### PR DESCRIPTION
A nit-picky, but we can use a [new syntax of the types union](https://docs.python.org/3/library/stdtypes.html#types-union) since this plugin only supports Python>=3.13.